### PR TITLE
Add catkin package build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,25 @@ set( TRAXXS_LIB_NAME traxxs )
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/)
 
-option(BUILD_DOC "Build documentation" ON)
+option( BUILD_DOC "Build documentation" OFF)
 option( USE_TG_SOFTMOTION "use softmotion trajectory generator" ON )
 option( USE_TG_SCURVETRAJGEN "use scurve_traj_gen trajectory generator" OFF )
 
 option( BUILD_SAMPLES "build samples" ON )
+
+#################### Catkin ###########################
+find_package(catkin QUIET)
+if(catkin_FOUND)
+    catkin_package(
+        INCLUDE_DIRS include/
+        external/soft_motion/soft-motion-libs/src/
+        external/scurve_traj_gen/scurve_traj_gen/src/
+        impl/softMotion/include/
+        impl/SCurveProfile/include/
+        LIBRARIES ${TRAXXS_LIB_NAME} traxxs_softmotion
+    )
+endif()
+#######################################################
 
 add_subdirectory( external )
 add_subdirectory( src )
@@ -81,4 +95,3 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/traxxsConfigVersion.cmake
     DESTINATION ${CONFIG_PACKAGE_LOCATION}
 )
-

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>traxxs</name>
+  <version>2.0.0</version>
+  <description>Traxxs</description>
+
+  <maintainer email="aurelien@akeolab.com">akeolab</maintainer>
+
+  <license>CeCILL-C</license>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+</package>


### PR DESCRIPTION
This is just a minimal `catkin` build which allows `traxxs` to be built in a `catkin` ws and exports its header paths and libraries in a way that other packages can use them via:

```
find_package(catkin REQUIRED COMPONENTS traxxs)
```

Also I set the documentation to NOT build by default. I wasn't sure if you wanted this or not, so I left it in but feel free to overwrite the change if you prefer to have the docs build automatically. 


